### PR TITLE
Added instructions to ignore OR REPLACE clause

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -254,8 +254,12 @@ ddlConstraint = pp.Group(
 ddlIfNotExists = pp.Group(
     pp.CaselessLiteral("IF") + pp.CaselessLiteral("NOT") + pp.CaselessLiteral("EXISTS")
 ).setResultsName("ifNotExists")
+ddlOrReplace = pp.Group(
+    pp.CaselessLiteral("OR") + pp.CaselessLiteral("REPLACE")
+).setResultsName("orReplace")
 ddlCreateTable = pp.Group(
     pp.CaselessLiteral("CREATE")
+    + pp.Suppress(pp.Optional(ddlOrReplace))
     + pp.CaselessLiteral("TABLE")
     + pp.Suppress(pp.Optional(ddlIfNotExists))
     + ddlName.setResultsName("tableName")


### PR DESCRIPTION
ddl parser failed if the create script contained CREATE OR REPLACE TABLE ... type of instructions. This patch fixes that by ignoring the OR REPLACE clause. Already tested it and works ok.